### PR TITLE
bugfix/#25268_missing_scripts_in_monitors

### DIFF
--- a/dist/net-snmp.spec
+++ b/dist/net-snmp.spec
@@ -184,7 +184,7 @@ options+=(--sysconfdir="/etc")
 options+=(--libdir=%{_libdir})
 options+=(--with-cflags="$RPM_OPT_FLAGS %{netsnmp_cflags}")
 options+=(--with-defaults)
-options+=(--with-mib-modules="smux")
+options+=(--with-mib-modules="smux ucd-snmp/diskio")
 options+=(--with-sys-contact="Unknown")
 options+=(--with-rdkafka)
 %if 0%{?netsnmp_perl_modules}


### PR DESCRIPTION

## Related issue in RedMine

- [Associated RedMine task](https://redmine.redborder.lan/issues/25268)

## Descripción

- Add flags so that diskio doesn't fail



